### PR TITLE
Add Tests to ParserTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,7 @@ checkstyle {
 run{
     standardInput = System.in
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -2,10 +2,7 @@ package seedu.duke.parser;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
-import seedu.duke.commands.AddCommand;
-import seedu.duke.commands.Command;
-import seedu.duke.commands.SetCommand;
-import seedu.duke.commands.TemplateCommand;
+import seedu.duke.commands.*;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,11 +10,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ParserTest {
 
     @Test
-    void parseTemplate_LrTemplate_returnsTemplateCommand() throws DukeException {
+    void parse_noLine_expectException() {
         Parser p = new Parser();
-        String line = "template rl";
+        String line = "";
+        assertThrows(DukeException.class, () -> p.parse(line));
+    }
+
+    @Test
+    void parseHelp_help_returnsHelpCommand() throws DukeException {
+        Parser p = new Parser();
+        String line = "help";
         Command c = p.parse(line);
-        assertTrue(c instanceof TemplateCommand);
+        assertTrue(c instanceof Command); // change to HelpCommand once done
+    }
+
+    @Test
+    void parseTemplate_Template_returnsTemplateCommand() throws DukeException {
+        Parser p = new Parser();
+        String line = "template ";
+        String[] tmp = {"r", "rl", "rc", "lc"};
+        Command c;
+        for (String s : tmp) {
+            c = p.parse(line + s);
+            assertTrue(c instanceof TemplateCommand);
+        }
     }
 
     @Test
@@ -103,6 +119,33 @@ class ParserTest {
         String line = "add series c 500";
         Command c = p.parse(line);
         assertTrue(c instanceof AddCommand);
+    }
+
+    @Test
+    void parseCalc_valueEff_CalculateCommand() throws DukeException {
+        Parser p = new Parser();
+        p.parse("template rl");
+        String line = "calc ";
+        String[] valueEff = {"reff", "leff", "current", "power"};
+        Command c;
+        for (String s : valueEff) {
+            c = p.parse(line + s);
+            assertTrue(c instanceof CalculateCommand);
+        }
+
+        p.parse("template rc");
+        String capEff = "ceff";
+        c = p.parse(line + capEff);
+        assertTrue(c instanceof CalculateCommand);
+
+    }
+
+    @Test
+    void parseExit_bye_ExitCommand() throws DukeException {
+        Parser p = new Parser();
+        String line = "bye";
+        Command c = p.parse(line);
+        assertTrue(c instanceof ExitCommand);
     }
 
 

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -33,9 +33,9 @@ class ParserTest {
     void parseTemplate_Template_returnsTemplateCommand() throws DukeException {
         Parser p = new Parser();
         String line = "template ";
-        String[] tmp = {"r", "rl", "rc", "lc"};
+        String[] templates = {"r", "rl", "rc", "lc"};
         Command c;
-        for (String s : tmp) {
+        for (String s : templates) {
             c = p.parse(line + s);
             assertTrue(c instanceof TemplateCommand);
         }
@@ -131,9 +131,9 @@ class ParserTest {
         Parser p = new Parser();
         p.parse("template rl");
         String line = "calc ";
-        String[] valueEff = {"reff", "leff", "current", "power"};
+        String[] effValues = {"reff", "leff", "current", "power"};
         Command c;
-        for (String s : valueEff) {
+        for (String s : effValues) {
             c = p.parse(line + s);
             assertTrue(c instanceof CalculateCommand);
         }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -2,7 +2,12 @@ package seedu.duke.parser;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
-import seedu.duke.commands.*;
+import seedu.duke.commands.AddCommand;
+import seedu.duke.commands.CalculateCommand;
+import seedu.duke.commands.Command;
+import seedu.duke.commands.ExitCommand;
+import seedu.duke.commands.SetCommand;
+import seedu.duke.commands.TemplateCommand;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -148,5 +153,10 @@ class ParserTest {
         assertTrue(c instanceof ExitCommand);
     }
 
-
+    @Test
+    void parse_invalidCommand_expectException() {
+        Parser p = new Parser();
+        String line = "invaliddd";
+        assertThrows(DukeException.class, () -> p.parse(line));
+    }
 }

--- a/text-ui-test/runtest.bat
+++ b/text-ui-test/runtest.bat
@@ -12,7 +12,7 @@ for /f "tokens=*" %%a in (
     set jarloc=%%a
 )
 
-java -jar %jarloc% < ..\..\text-ui-test\input.txt > ..\..\text-ui-test\ACTUAL.TXT
+java -jar -Dfile.encoding=UTF-8 %jarloc% < ..\..\text-ui-test\input.txt > ..\..\text-ui-test\ACTUAL.TXT
 
 cd ..\..\text-ui-test
 


### PR DESCRIPTION
Add the following to `gradle.properties` for the `.jar` file to display the units `Ω`, `μ` properly:

```
tasks.withType(JavaCompile) {
    options.encoding = 'UTF-8'
}
```
along with `runtest.bat` to properly run with the UTF-8 encoding adding `-Dfile.encoding=UTF-8` to the command.

Update of `ParserTest`:

* Add `parseHelp` for parsing of `help` to `HelpCommand` - still to add by @sevenseasofbri for #7.
* Update `parseTemplate` to include all templates.
* Add `parseCalc` for `calc` to `CalculateCommand`.
* Add `parseExit` for `exit` to `ExitCommand`.
* Add `parseInvalid` for invalid command to throw `DukeException`.

Part of #29.