### PR TITLE
Refactor Ui out of Command

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -22,8 +22,9 @@ public class Duke {
             try {
                 String line = ui.readLine();
                 Command c = parser.parse(line);
-                c.execute(ui);
+                c.execute();
                 isExit = c.isExit();
+                ui.printMessage(c.toString());
             } catch (DukeException e) {
                 ui.showError(e.getMessage());
             }

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -3,10 +3,10 @@ package seedu.duke.commands;
 import seedu.duke.DukeException;
 import seedu.duke.component.LoadComponent;
 import seedu.duke.template.Template;
-import seedu.duke.ui.Ui;
 
 public class AddCommand extends SetCommand {
     private final String config;
+    private LoadComponent loadComponent;
 
     public AddCommand(Template template, String config, String component, double value) {
         super(template, component, value);
@@ -16,18 +16,16 @@ public class AddCommand extends SetCommand {
     /**
      * Executes appropriate methods based on the given command.
      *
-     * @param ui Ui object.
      */
     @Override
-    public void execute(Ui ui) throws DukeException {
+    public void execute() throws DukeException {
         LoadComponent c = template.getComponent(component);
         double newValue = getNewValue();
 
         c.setValue(value);
-        ui.printAddComponent(c);
+        loadComponent = c;
 
         template.setComponent(component, newValue);
-        ui.printTemplate(template);
     }
 
     private double getNewValue() throws DukeException {
@@ -39,4 +37,13 @@ public class AddCommand extends SetCommand {
         }
     }
 
+    /**
+     * String representation of the Command.
+     *
+     * @return String representation.
+     */
+    @Override
+    public String toString() {
+        return "Nice, added a " + loadComponent + '\n' + template;
+    }
 }

--- a/src/main/java/seedu/duke/commands/CalculateCommand.java
+++ b/src/main/java/seedu/duke/commands/CalculateCommand.java
@@ -1,17 +1,13 @@
 package seedu.duke.commands;
 
 import seedu.duke.DukeException;
-import seedu.duke.template.LcTemplate;
-import seedu.duke.template.LrTemplate;
-import seedu.duke.template.RTemplate;
-import seedu.duke.template.RcTemplate;
 import seedu.duke.template.Template;
-import seedu.duke.ui.Ui;
 
 public class CalculateCommand extends Command {
-    private String calculationType;
+    private final String calculationType;
+    private String value;
 
-    public CalculateCommand(Template template,String calculationType) {
+    public CalculateCommand(Template template, String calculationType) {
         super(template);
         this.calculationType = calculationType;
     }
@@ -19,73 +15,50 @@ public class CalculateCommand extends Command {
     /**
      * Executes calculate command.
      *
-     * @param ui Ui object.
      * @throws DukeException If execution error occurs.
      */
     @Override
-    public void execute(Ui ui) throws DukeException {
+    public void execute() throws DukeException {
+        value = getValue();
+    }
+
+    private String getValue() throws DukeException {
         switch (calculationType) {
         case "power":
-            ui.printCalculatedPower(template.getPower());
-            break;
+            return template.getPower() + "W";
         case "current":
-            ui.printCalculatedCurrent(template.getCurrent());
-            break;
+            return template.getCurrent() + "A";
         case "reff":
-            calculateReff(ui);
-            break;
+            return template.getComponent("r").toString();
         case "ceff":
-            calculateCeff(ui);
-            break;
+            return template.getComponent("c").toString();
+        case "leff":
+            return template.getComponent("l").toString();
         default:
-            calculateLeff(ui);
-            break;
+            throw new DukeException("No such value");
         }
     }
 
     /**
-     * Calculates and prints the effective resistance of the circuit.
+     * String representation of the Command.
      *
-     * @param ui Ui object.
-     * @throws DukeException If the chosen template does not contain resistors.
+     * @return String representation.
      */
-    private void calculateReff(Ui ui) throws DukeException {
-        if (template instanceof RTemplate) {
-            ui.printCalculatedResistance(((RTemplate)template).getResistor());
-        } else {
-            throw new DukeException("Chosen template does not contain resistors! :( ");
-        }
-    }
-
-    /**
-     * Calculates and prints the effective capacitance of the circuit.
-     *
-     * @param ui Ui object.
-     * @throws DukeException If the chosen template does not contain capacitors.
-     */
-    private void calculateCeff(Ui ui) throws DukeException {
-        if (template instanceof LcTemplate) {
-            ui.printCalculatedCapacitance(((LcTemplate) template).getCapacitor());
-        } else if (template instanceof RcTemplate) {
-            ui.printCalculatedCapacitance(((RcTemplate) template).getCapacitor());
-        } else {
-            throw new DukeException("Chosen template does not contain capacitors! :( ");
-        }
-    }
-
-    /**
-     * Calculates and prints the effective inductance of the circuit.
-     *
-     * @param ui Ui object.
-     * @throws DukeException If the chosen template does not contain inductors.
-     */
-    private void calculateLeff(Ui ui) throws DukeException {
-        if (template instanceof LcTemplate) {
-            ui.printCalculatedInductance(((LcTemplate) template).getInductor());
-        } else if (template instanceof LrTemplate) {
-            ui.printCalculatedInductance(((LrTemplate) template).getInductor());
-        } else {
-            throw new DukeException("Chosen template does not contain inductors! :( ");
+    @Override
+    public String toString() {
+        switch (calculationType) {
+        case "power":
+            return "The power dissipated in the circuit is " + value;
+        case "current":
+            return "The total rms current flowing through the circuit is " + value;
+        case "reff":
+            return "The effective resistance calculated is " + value;
+        case "ceff":
+            return "The effective capacitance calculated is " + value;
+        case "leff":
+            return "The effective inductance calculated is " + value;
+        default:
+            return "Unknown calculation type!";
         }
     }
 }

--- a/src/main/java/seedu/duke/commands/Command.java
+++ b/src/main/java/seedu/duke/commands/Command.java
@@ -2,29 +2,24 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.template.Template;
-import seedu.duke.ui.Ui;
 
-public class Command {
+public abstract class Command {
     /** Boolean whether the command is to exit. **/
     protected boolean isExit;
     protected Template template;
 
-    public Command(Template template) {
+    protected Command(Template template) {
         this.template = template;
     }
 
-    public Command() {
+    protected Command() {
         this(null);
     }
 
     /**
      * Executes appropriate methods based on the given command.
-     *
-     * @param ui Ui object.
-     * @throws DukeException If an execution error occurs.
      */
-    public void execute(Ui ui) throws DukeException {
-    }
+    public abstract void execute() throws DukeException;
 
 
     /**

--- a/src/main/java/seedu/duke/commands/ExitCommand.java
+++ b/src/main/java/seedu/duke/commands/ExitCommand.java
@@ -1,19 +1,21 @@
 package seedu.duke.commands;
 
-import seedu.duke.ui.Ui;
-
 public class ExitCommand extends Command {
-    public ExitCommand() {
+    /**
+     * Executes the exit command.
+     */
+    @Override
+    public void execute() {
         isExit = true;
     }
 
     /**
-     * Executes the exit command message.
+     * String representation of the Command.
      *
-     * @param ui Ui object.
+     * @return String representation.
      */
     @Override
-    public void execute(Ui ui) {
-        ui.printFarewell();
+    public String toString() {
+        return " Bye. See you next time!";
     }
 }

--- a/src/main/java/seedu/duke/commands/HelpCommand.java
+++ b/src/main/java/seedu/duke/commands/HelpCommand.java
@@ -4,24 +4,22 @@ import seedu.duke.DukeException;
 import seedu.duke.parser.Parser;
 import seedu.duke.ui.Ui;
 
-import java.util.Scanner;
-
 public class HelpCommand extends Command {
     private static final Parser PARSER = new Parser();
-    private int numOfCommandsDone = 0;
     private static final String[] orderOfInstructions = {"template", "set v", "set", "set", "add", "calc"};
+    private int numOfCommandsDone = 0;
+    private final Ui ui;
 
     public HelpCommand() {
         super();
+        ui = new Ui(); // Create its own Ui instance, can be a Ui subclass later on
     }
 
     /**
      * Begins execution of the interactive tutorial.
-     *
-     * @param ui Ui object.
      */
     @Override
-    public void execute(Ui ui) {
+    public void execute() {
         ui.printWelcomeTutorial();
         String command;
         boolean isNotDone = true;
@@ -35,7 +33,6 @@ public class HelpCommand extends Command {
                 ui.showError(e.getMessage());
             }
         }
-        ui.printExitHelp();
     }
 
     private boolean continueTutorial(String command, Ui ui) throws DukeException {
@@ -49,8 +46,19 @@ public class HelpCommand extends Command {
         }
         
         Command c = PARSER.parse(command);
-        c.execute(ui);
+        c.execute();
+        ui.printMessage(c.toString());
         numOfCommandsDone++;
         return true;
+    }
+
+    /**
+     * String representation of the Command.
+     *
+     * @return String representation.
+     */
+    @Override
+    public String toString() {
+        return ":) Have fun using CLIrcuit Assistant!";
     }
 }

--- a/src/main/java/seedu/duke/commands/SetCommand.java
+++ b/src/main/java/seedu/duke/commands/SetCommand.java
@@ -1,13 +1,17 @@
 package seedu.duke.commands;
 
 import seedu.duke.DukeException;
-import seedu.duke.component.LoadComponent;
+import seedu.duke.component.Capacitor;
+import seedu.duke.component.Component;
+import seedu.duke.component.Inductor;
+import seedu.duke.component.Resistor;
+import seedu.duke.component.VoltageSource;
 import seedu.duke.template.Template;
-import seedu.duke.ui.Ui;
 
 public class SetCommand extends Command {
     protected final String component;
     protected final double value;
+    protected Component componentObject;
 
     public SetCommand(Template template, String component, double value) {
         super(template);
@@ -18,22 +22,43 @@ public class SetCommand extends Command {
     /**
      * Executes set command.
      *
-     * @param ui Ui object.
      * @throws DukeException If execution error occurs.
      */
     @Override
-    public void execute(Ui ui) throws DukeException {
+    public void execute() throws DukeException {
         if (component.equals("v")) {
             template.setInitialPowerSupply(value);
-            ui.printSetVoltageSource(template.getInitialPowerSupply());
+            componentObject = template.getInitialPowerSupply();
             return;
         }
-        LoadComponent c = template.getComponent(component);
+        componentObject = template.getComponent(component);
 
-        c.setValue(value);
-        ui.printSetComponent(c);
+        componentObject.setValue(value);
 
         template.setComponent(component, value);
-        ui.printTemplate(template);
+    }
+
+    /**
+     * String representation of the Command.
+     *
+     * @return String representation.
+     */
+    @Override
+    public String toString() {
+        if (componentObject instanceof VoltageSource) {
+            return "The voltage source was changed to: " + componentObject;
+        }
+
+        String componentName = "";
+
+        if (componentObject instanceof Resistor) {
+            componentName = "resistor";
+        } else if (componentObject instanceof Capacitor) {
+            componentName = "capacitor";
+        } else if (componentObject instanceof Inductor) {
+            componentName = "inductor";
+        }
+
+        return "The " + componentName + " was set to " + componentObject + '\n' + template;
     }
 }

--- a/src/main/java/seedu/duke/commands/SummaryCommand.java
+++ b/src/main/java/seedu/duke/commands/SummaryCommand.java
@@ -1,19 +1,32 @@
 package seedu.duke.commands;
 
-import seedu.duke.ui.Ui;
-
 public class SummaryCommand extends Command {
+    private static final String COMMAND_SUMMARY = "\n"
+            + "+-----------+----------------------------+--------------------+\n"
+            + "|  Action   |           Format           |      Examples      |\n"
+            + "+-----------+----------------------------+--------------------+\n"
+            + "| Help      | help                       | help               |\n"
+            + "| Template  | template TEMPLATE          | template rc        |\n"
+            + "| Set       | set COMPONENT VALUE        | set r 500          |\n"
+            + "| Add       | add CONFIG COMPONENT VALUE | add parallel c 500 |\n"
+            + "| Calculate | calc EFF_VALUE             | calc ceff          |\n"
+            + "+-----------+----------------------------+--------------------+\n";
+
     public SummaryCommand() {
         super();
     }
 
+    @Override
+    public void execute() {
+    }
+
     /**
-     * Prints a summary of the commands.
+     * String representation of the Command.
      *
-     * @param ui Ui object.
+     * @return String representation.
      */
     @Override
-    public void execute(Ui ui) {
-        ui.printCommandSummary();
+    public String toString() {
+        return COMMAND_SUMMARY;
     }
 }

--- a/src/main/java/seedu/duke/commands/TemplateCommand.java
+++ b/src/main/java/seedu/duke/commands/TemplateCommand.java
@@ -1,7 +1,6 @@
 package seedu.duke.commands;
 
 import seedu.duke.template.Template;
-import seedu.duke.ui.Ui;
 
 public class TemplateCommand extends Command {
 
@@ -9,13 +8,12 @@ public class TemplateCommand extends Command {
         super(template);
     }
 
-    /**
-    * Executes appropriate methods based on the given command.
-    *
-    * @param ui Ui object.
-    */
     @Override
-    public void execute(Ui ui) {
-        ui.printMessage(template.toString());
+    public void execute() {
+    }
+
+    @Override
+    public String toString() {
+        return template.toString();
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -121,6 +121,7 @@ public class Parser {
         }
 
         double value = Double.parseDouble(args[2]);
+        assert value > 0;
         return new SetCommand(template, args[1], value);
     }
 
@@ -140,6 +141,7 @@ public class Parser {
         }
 
         double value = Double.parseDouble(args[3]);
+        assert value > 0;
         return new AddCommand(template, args[1], args[2], value);
     }
 

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -41,17 +41,6 @@ public class Ui {
             + "Lets try it out. Type 'calc' followed by 'ceff'/'leff'/'reff'/'power'/'current' and enter. :D",
         "Great! You're set to use\n" + "CLIrcuit Assistant" + "Enjoy! :)\n type 'exit' to exit this mode.\n"};
 
-    private static final String COMMAND_SUMMARY = "\n"
-            + "+-----------+----------------------------+--------------------+\n"
-            + "|  Action   |           Format           |      Examples      |\n"
-            + "+-----------+----------------------------+--------------------+\n"
-            + "| Help      | help                       | help               |\n"
-            + "| Template  | template TEMPLATE          | template rc        |\n"
-            + "| Set       | set COMPONENT VALUE        | set r 500          |\n"
-            + "| Add       | add CONFIG COMPONENT VALUE | add parallel c 500 |\n"
-            + "| Calculate | calc EFF_VALUE             | calc ceff          |\n"
-            + "+-----------+----------------------------+--------------------+\n"
-            + "\n";
 
     private static final Scanner IN = new Scanner(System.in);
 
@@ -88,13 +77,6 @@ public class Ui {
     }
 
     /**
-     * Prints farewell message after exiting Duke.
-     */
-    public void printFarewell() {
-        System.out.println(" Bye. See you next time!");
-    }
-
-    /**
      * Prints a message.
      *
      * @param message Message.
@@ -112,110 +94,12 @@ public class Ui {
         printMessage(message);
     }
 
-
-    /**
-     * Prints that a component has been set.
-     *
-     * @param component LoadComponent object set.
-     */
-    public void printSetComponent(LoadComponent component) {
-        System.out.println("Set " + component);
-    }
-
-
-    /**
-     * Prints that a component has been added.
-     *
-     * @param component LoadComponent object added.
-     */
-    public void printAddComponent(LoadComponent component) {
-        System.out.println("Nice, added a " + component);
-    }
-
-    /**
-     * Prints the template that was chosen.
-     *
-     * @param template Template object.
-     */
-    public void printTemplate(Template template) {
-        System.out.println(template);
-    }
-
-    /**
-     * Prints the effective resistance that was calculated.
-     *
-     * @param resistor Resistor object.
-     */
-    public void printCalculatedResistance(Resistor resistor) {
-        System.out.println("The effective resistance calculated is " + resistor);
-    }
-
-    /**
-     * Prints the effective capacitance that was calculated.
-     *
-     * @param capacitor Capacitor object.
-     */
-    public void printCalculatedCapacitance(Capacitor capacitor) {
-        System.out.println("The effective capacitance calculated is " + capacitor);
-    }
-
-    /**
-     * Prints the effective inductance that was calculated.
-     *
-     * @param inductor Inductor object.
-     */
-    public void printCalculatedInductance(Inductor inductor) {
-        System.out.println("The effective inductance calculated is " + inductor);
-    }
-
-    /**
-     * Prints the power dissipated in the circuit.
-     *
-     * @param power double value.
-     */
-    public void printCalculatedPower(double power) {
-        System.out.println("The power dissipated in the circuit is " + power + "W");
-    }
-
-    /**
-     * Prints the current drawn by the circuit.
-     *
-     * @param current double value.
-     */
-    public void printCalculatedCurrent(double current) {
-        System.out.println("The total rms current flowing through the circuit is " + current + "A");
-    }
-
-    /**
-     * Prints the value of the voltage source after setting voltage.
-     *
-     * @param voltageSource VoltageSource object.
-     */
-    public void printSetVoltageSource(VoltageSource voltageSource) {
-        System.out.println("The voltage source was changed to: " + voltageSource);
-    }
-
     /**
      * Prints the welcome message for the tutorial mode.
      */
     public void printWelcomeTutorial() {
         System.out.println("You have entered Tutorial Mode!" + System.lineSeparator()
                 + "Type 'exit' if you want to leave this mode and go back to the application.");
-    }
-
-
-    /**
-     * Prints command summary.
-     */
-    public void printCommandSummary() {
-        System.out.print(COMMAND_SUMMARY);
-    }
-
-    /**
-     * Prints exit statement for the help mode.
-     */
-    public void printExitHelp() {
-        System.out.println(":) Have fun using CLIrcuit Assistant!");
     }
 
     /**

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -3,13 +3,11 @@ package seedu.duke.commands;
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
 import seedu.duke.template.RcTemplate;
-import seedu.duke.ui.Ui;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AddCommandTest {
-    private static final Ui UI = new Ui();
     private static final RcTemplate TEMPLATE = new RcTemplate(500, 500, 5);
     private static final String CONFIG = "series";
     private static final String COMPONENT = "r";
@@ -18,13 +16,13 @@ class AddCommandTest {
     @Test
     void execute_addResistor_setsResistor() throws DukeException {
         AddCommand c = new AddCommand(TEMPLATE, CONFIG, COMPONENT, VALUE);
-        c.execute(UI);
+        c.execute();
         assertEquals(1000, c.template.getComponent("r").getValue());
     }
 
     @Test
     void execute_wrongComponent_expectException() {
         AddCommand c = new AddCommand(TEMPLATE, CONFIG, "l", VALUE);
-        assertThrows(DukeException.class, () -> c.execute(UI));
+        assertThrows(DukeException.class, c::execute);
     }
 }

--- a/src/test/java/seedu/duke/commands/CalculateCommandTest.java
+++ b/src/test/java/seedu/duke/commands/CalculateCommandTest.java
@@ -5,14 +5,12 @@ import seedu.duke.DukeException;
 import seedu.duke.template.LcTemplate;
 import seedu.duke.template.LrTemplate;
 import seedu.duke.template.RTemplate;
-import seedu.duke.ui.Ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class CalculateCommandTest {
-    private static final Ui UI = new Ui();
     private static final RTemplate RTEMPLATE = new RTemplate(100, 100);
     private static final LrTemplate LR_TEMPLATE = new LrTemplate(0, 0, 10);
     private static final LcTemplate LC_TEMPLATE = new LcTemplate(1600, 299, 220);
@@ -24,25 +22,25 @@ public class CalculateCommandTest {
     @Test
     void execute_calcPower_calculatesPower() throws DukeException {
         CalculateCommand c = new CalculateCommand(RTEMPLATE, POWER);
-        c.execute(UI);
+        c.execute();
         assertEquals(100, c.template.getPower());
     }
 
     @Test
-    void execute_calcCeff_calculatesEffectiveCapacitance() throws DukeException {
+    void execute_calcCeff_calculatesEffectiveCapacitance() {
         CalculateCommand c = new CalculateCommand(LC_TEMPLATE, CAPACITANCE);
-        assertDoesNotThrow(() -> c.execute(UI));
+        assertDoesNotThrow(c::execute);
     }
 
     @Test
     void execute_calcCurrentWithZeroValueComponents_expectException() {
         CalculateCommand c = new CalculateCommand(LR_TEMPLATE, CURRENT);
-        assertThrows(DukeException.class, () -> c.execute(UI));
+        assertThrows(DukeException.class, c::execute);
     }
 
     @Test
     void execute_invalidComponentForTemplate_expectException() {
         CalculateCommand c = new CalculateCommand(RTEMPLATE, INDUCTANCE);
-        assertThrows(DukeException.class, () -> c.execute(UI));
+        assertThrows(DukeException.class, c::execute);
     }
 }

--- a/src/test/java/seedu/duke/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/duke/commands/ExitCommandTest.java
@@ -1,9 +1,7 @@
 package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
-import seedu.duke.ui.Ui;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -11,8 +9,8 @@ public class ExitCommandTest {
 
     @Test
     void execute_run_setsExit() {
-        Ui ui = new Ui();
         ExitCommand c = new ExitCommand();
+        c.execute();
         assertTrue(c.isExit());
     }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -30,7 +30,7 @@ eg. To select the Resistor-Capacitor circuit template, enter 'template rc.'
 Total Resistance: 0.0 Ω
 Total Inductance: 0.0 µH
 
-Set 2.0 Ω
+The resistor was set to 2.0 Ω
 	+---R-----L---+
 	|             |
 	|             |
@@ -38,7 +38,7 @@ Set 2.0 Ω
 Total Resistance: 2.0 Ω
 Total Inductance: 0.0 µH
 
-Set 3.0 µH
+The inductor was set to 3.0 µH
 	+---R-----L---+
 	|             |
 	|             |
@@ -46,7 +46,7 @@ Set 3.0 µH
 Total Resistance: 2.0 Ω
 Total Inductance: 3.0 µH
 
-Nice, added a 2.0 Ω
+Nice, added a 4.0 Ω
 	+---R-----L---+
 	|             |
 	|             |
@@ -54,7 +54,7 @@ Nice, added a 2.0 Ω
 Total Resistance: 4.0 Ω
 Total Inductance: 3.0 µH
 
-Nice, added a 2.0 µH
+Nice, added a 5.0 µH
 	+---R-----L---+
 	|             |
 	|             |
@@ -62,7 +62,7 @@ Nice, added a 2.0 µH
 Total Resistance: 4.0 Ω
 Total Inductance: 5.0 µH
 
-Nice, added a 2.0 Ω
+Nice, added a 1.3333333333333333 Ω
 	+---R-----L---+
 	|             |
 	|             |
@@ -70,7 +70,7 @@ Nice, added a 2.0 Ω
 Total Resistance: 1.3333333333333333 Ω
 Total Inductance: 5.0 µH
 
-Set 3.0 Ω
+The resistor was set to 3.0 Ω
 	+---R-----L---+
 	|             |
 	|             |


### PR DESCRIPTION
* Reduce coupling between `Command` and `Ui` by removing all uses of `Ui` (except for `HelpCommand`).
* Add `assert value > 0` in `Parser.prepareSet()` and `Parser.prepareAdd()`. (#47)
* Update JUnit to remove `Ui`.